### PR TITLE
The type should not be a required parameter to WebhookResponseParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,25 @@ api.getApiClient().setUsername(clearbit_key);
 Company company = api.streamingLookup("clearbit.com");
 ```
 
-The API is blocking by default - it holds a streaming connection open (this can take 3~5 seconds if we haven't seen the email before).
+This API is blocking by default - it holds a streaming connection open (this can take 3~5 seconds if we haven't seen the email before). We recommend using the webhook API for higher throughput.
+
+To parse the response received from a webhook call, use the WebhookResponseParser:
+
+```java
+final String clearbit_key = System.getenv("CLEARBIT_KEY");
+WebhookResponseParser parser = new WebhookResponseParser(clearbit_key);
+WebhookResponse response = parser.parse(responseBody, xRequestSignatureHeader);
+switch (response.getType()) {
+  case PERSON:
+    Person person = (Person) response.getBody();
+    break;
+  case COMPANY:
+    Company company = (Company) response.getBody();
+    break;
+  default:
+    throw new IllegalStateException("Unexpected type: " + response.getType());
+}
+```
 
 ## Supported APIs
 

--- a/src/main/lombok/com/clearbit/client/model/Type.java
+++ b/src/main/lombok/com/clearbit/client/model/Type.java
@@ -1,0 +1,8 @@
+package com.clearbit.client.model;
+
+public enum Type {
+
+  PERSON,
+  COMPANY;
+  
+}

--- a/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
+++ b/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
@@ -5,11 +5,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 @Data
-public class WebhookResponse<T> {
+public class WebhookResponse {
 
-  T body;
+  Type type;
+  Object body;
   int status;
-  String type;
   String id;
 
 }


### PR DESCRIPTION
We don't know what the type will be until the response is parsed so it was very difficult to call this API. This change fixes that making it much easier to use