### PR TITLE
Migrate the Person/Company APIs to v2 URLs

### DIFF
--- a/src/main/java/com/clearbit/client/api/CompanyApi.java
+++ b/src/main/java/com/clearbit/client/api/CompanyApi.java
@@ -77,7 +77,6 @@ public class CompanyApi {
 
   // doReq handles the HTTP request to the API endpoint 
   private Company doReq(String uri) throws ApiException {
-	// req params
 	Object postBody = null;
 	byte[] postBinaryBody = null;
 	

--- a/src/main/java/com/clearbit/client/api/CompanyApi.java
+++ b/src/main/java/com/clearbit/client/api/CompanyApi.java
@@ -16,6 +16,7 @@ public class CompanyApi {
 
   private ApiClient apiClient;
   private String COMPANY_URL = "https://company.clearbit.com/v2/companies/find";
+  private String STREAMING_URL = "https://company-stream.clearbit.com/v2/companies/find";
 
   public CompanyApi() {
     this(Configuration.getDefaultApiClient());
@@ -39,28 +40,15 @@ public class CompanyApi {
    * @return Company
    */
   public Company streamingLookup(String domain) throws ApiException {
-    Object postBody = null;
-    byte[] postBinaryBody = null;
-
      // verify the required parameters are set
      if (domain == null) {
         throw new ApiException(400, "Missing the required parameter 'domain' when calling CompanyApi.streamingLookup");
      }
 
-    // create path and map variables
-    String path = "https://company-stream.clearbit.com/v1/companies/domain/{domain}".replaceAll("\\{" + "domain" + "\\}", apiClient.escapeString(domain.toString()));
+     // create path and add url params
+     String uri = this.STREAMING_URL + "?domain=" + apiClient.escapeString(domain.toString());
 
-    // query params
-    List<Pair> queryParams = new ArrayList<Pair>();
-    Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, Object> formParams = new HashMap<String, Object>();
-    String accept = apiClient.selectHeaderAccept(new String[]{});
-    String contentType = apiClient.selectHeaderContentType(new String[]{});
-
-    String[] authNames = new String[] { "Basic Authentication" };
-
-    TypeRef<Company> returnType = new TypeRef<Company>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
+     return this.doReq(uri);
   }
 
   /**
@@ -70,32 +58,36 @@ public class CompanyApi {
    * @return Company
    */
   public Company lookup(String domain, String webhookId) throws ApiException {
-    Object postBody = null;
-    byte[] postBinaryBody = null;
-
      // verify the required parameters are set
      if (domain == null) {
         throw new ApiException(400, "Missing the required parameter 'domain' when calling CompanyApi.lookup");
      }
 
-    // create path and map variables
-    String path = this.COMPANY_URL + "?domain=" +  apiClient.escapeString(domain.toString());
+     // create path and add url params
+     String uri = this.COMPANY_URL + "?domain=" + apiClient.escapeString(domain.toString());
 
-    if (webhookId != null) {
-      path += "&webhook_id=" + apiClient.escapeString(webhookId.toString());
-    }
+     if (webhookId != null) {
+    	uri += "&webhook_id=" + apiClient.escapeString(webhookId.toString());
+     }
 
-    // query params
-    List<Pair> queryParams = new ArrayList<Pair>();
-    Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, Object> formParams = new HashMap<String, Object>();
-    String accept = apiClient.selectHeaderAccept(new String[]{});
-    String contentType = apiClient.selectHeaderContentType(new String[]{});
+     return this.doReq(uri);
+ }
 
-    String[] authNames = new String[] { "Basic Authentication" };
+  private Company doReq(String uri) throws ApiException {
+	  // req params
+	  Object postBody = null;
+	  byte[] postBinaryBody = null;
 
-    TypeRef<Company> returnType = new TypeRef<Company>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
+	  // query params
+	  List<Pair> queryParams = new ArrayList<Pair>();
+	  Map<String, String> headerParams = new HashMap<String, String>();
+	  Map<String, Object> formParams = new HashMap<String, Object>();
+	  String accept = apiClient.selectHeaderAccept(new String[]{});
+	  String contentType = apiClient.selectHeaderContentType(new String[]{});
+
+	  String[] authNames = new String[] { "Basic Authentication" };
+
+	  TypeRef<Company> returnType = new TypeRef<Company>() {};
+	  return apiClient.invokeAPI(uri, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
   }
-
 }

--- a/src/main/java/com/clearbit/client/api/CompanyApi.java
+++ b/src/main/java/com/clearbit/client/api/CompanyApi.java
@@ -14,9 +14,9 @@ import com.clearbit.client.model.Company;
 
 public class CompanyApi {
 
-  private ApiClient apiClient;
-  private String COMPANY_URL = "https://company.clearbit.com/v2/companies/find";
-  private String STREAMING_URL = "https://company-stream.clearbit.com/v2/companies/find";
+  private final ApiClient apiClient;
+  private final String URL = "https://company.clearbit.com/v2/companies/find";
+  private final String STREAMING_URL = "https://company-stream.clearbit.com/v2/companies/find";
 
   public CompanyApi() {
     this(Configuration.getDefaultApiClient());
@@ -58,7 +58,7 @@ public class CompanyApi {
   public Company lookup(String domain) throws ApiException {
 	  return this.lookup(domain, null);
   }
-  
+
   public Company lookup(String domain, String webhookId) throws ApiException {
      // verify the required parameters are set
      if (domain == null) {
@@ -66,7 +66,7 @@ public class CompanyApi {
      }
 
      // create path and add url params
-     String uri = this.COMPANY_URL + "?domain=" + apiClient.escapeString(domain.toString());
+     String uri = this.URL + "?domain=" + apiClient.escapeString(domain.toString());
 
      if (webhookId != null) {
     	uri += "&webhook_id=" + apiClient.escapeString(webhookId.toString());
@@ -75,11 +75,11 @@ public class CompanyApi {
      return this.doReq(uri);
  }
 
-  // doReq handles the HTTP request to the API endpoint 
+  // doReq handles the HTTP request to the API endpoint
   private Company doReq(String uri) throws ApiException {
 	Object postBody = null;
 	byte[] postBinaryBody = null;
-	
+
 	// query params
 	List<Pair> queryParams = new ArrayList<Pair>();
 	Map<String, String> headerParams = new HashMap<String, String>();

--- a/src/main/java/com/clearbit/client/api/CompanyApi.java
+++ b/src/main/java/com/clearbit/client/api/CompanyApi.java
@@ -55,6 +55,10 @@ public class CompanyApi {
    * @param domain the company's website domain
    * @return Company
    */
+  public Company lookup(String domain) throws ApiException {
+	  return this.lookup(domain, null);
+  }
+  
   public Company lookup(String domain, String webhookId) throws ApiException {
      // verify the required parameters are set
      if (domain == null) {

--- a/src/main/java/com/clearbit/client/api/CompanyApi.java
+++ b/src/main/java/com/clearbit/client/api/CompanyApi.java
@@ -15,6 +15,7 @@ import com.clearbit.client.model.Company;
 public class CompanyApi {
 
   private ApiClient apiClient;
+  private String COMPANY_URL = "https://company.clearbit.com/v2/companies/find";
 
   public CompanyApi() {
     this(Configuration.getDefaultApiClient());
@@ -28,6 +29,8 @@ public class CompanyApi {
     return apiClient;
   }
 
+
+
   /**
    * The Company API lets you lookup company data via a domain name.
    * This is a blocking operation. If the company is not in the Clearbit database,
@@ -38,12 +41,12 @@ public class CompanyApi {
   public Company streamingLookup(String domain) throws ApiException {
     Object postBody = null;
     byte[] postBinaryBody = null;
-    
+
      // verify the required parameters are set
      if (domain == null) {
         throw new ApiException(400, "Missing the required parameter 'domain' when calling CompanyApi.streamingLookup");
      }
-     
+
     // create path and map variables
     String path = "https://company-stream.clearbit.com/v1/companies/domain/{domain}".replaceAll("\\{" + "domain" + "\\}", apiClient.escapeString(domain.toString()));
 
@@ -69,18 +72,17 @@ public class CompanyApi {
   public Company lookup(String domain, String webhookId) throws ApiException {
     Object postBody = null;
     byte[] postBinaryBody = null;
-    
+
      // verify the required parameters are set
      if (domain == null) {
         throw new ApiException(400, "Missing the required parameter 'domain' when calling CompanyApi.lookup");
      }
-     
+
     // create path and map variables
-    String path = "https://company.clearbit.com/v1/companies/domain/{domain}"
-        .replaceAll("\\{" + "domain" + "\\}", apiClient.escapeString(domain.toString()));
+    String path = this.COMPANY_URL + "?domain=" +  apiClient.escapeString(domain.toString());
 
     if (webhookId != null) {
-      path += "?webhook_id=" + apiClient.escapeString(webhookId.toString());
+      path += "&webhook_id=" + apiClient.escapeString(webhookId.toString());
     }
 
     // query params

--- a/src/main/java/com/clearbit/client/api/CompanyApi.java
+++ b/src/main/java/com/clearbit/client/api/CompanyApi.java
@@ -30,8 +30,6 @@ public class CompanyApi {
     return apiClient;
   }
 
-
-
   /**
    * The Company API lets you lookup company data via a domain name.
    * This is a blocking operation. If the company is not in the Clearbit database,
@@ -73,21 +71,22 @@ public class CompanyApi {
      return this.doReq(uri);
  }
 
+  // doReq handles the HTTP request to the API endpoint 
   private Company doReq(String uri) throws ApiException {
-	  // req params
-	  Object postBody = null;
-	  byte[] postBinaryBody = null;
+	// req params
+	Object postBody = null;
+	byte[] postBinaryBody = null;
+	
+	// query params
+	List<Pair> queryParams = new ArrayList<Pair>();
+	Map<String, String> headerParams = new HashMap<String, String>();
+	Map<String, Object> formParams = new HashMap<String, Object>();
+	String accept = apiClient.selectHeaderAccept(new String[]{});
+	String contentType = apiClient.selectHeaderContentType(new String[]{});
 
-	  // query params
-	  List<Pair> queryParams = new ArrayList<Pair>();
-	  Map<String, String> headerParams = new HashMap<String, String>();
-	  Map<String, Object> formParams = new HashMap<String, Object>();
-	  String accept = apiClient.selectHeaderAccept(new String[]{});
-	  String contentType = apiClient.selectHeaderContentType(new String[]{});
+	String[] authNames = new String[] { "Basic Authentication" };
 
-	  String[] authNames = new String[] { "Basic Authentication" };
-
-	  TypeRef<Company> returnType = new TypeRef<Company>() {};
-	  return apiClient.invokeAPI(uri, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
+	TypeRef<Company> returnType = new TypeRef<Company>() {};
+	return apiClient.invokeAPI(uri, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
   }
 }

--- a/src/main/java/com/clearbit/client/api/PersonApi.java
+++ b/src/main/java/com/clearbit/client/api/PersonApi.java
@@ -14,7 +14,9 @@ import com.clearbit.client.model.Person;
 
 public class PersonApi {
 
-  private ApiClient apiClient;
+  private final ApiClient apiClient;
+  private final String URL = "https://person.clearbit.com/v2/people/find";
+  private final String STREAMING_URL = "https://person-stream.clearbit.com/v2/people/find";
 
   public PersonApi() {
     this(Configuration.getDefaultApiClient());
@@ -37,28 +39,15 @@ public class PersonApi {
    * @return Person
    */
   public Person streamingLookup(String email) throws ApiException {
-    Object postBody = null;
-    byte[] postBinaryBody = null;
-    
-     // verify the required parameters are set
-     if (email == null) {
-        throw new ApiException(400, "Missing the required parameter 'email' when calling PersonApi.streamingLookup");
-     }
-     
+    // verify the required parameters are set
+    if (email == null) {
+      throw new ApiException(400, "Missing the required parameter 'email' when calling PersonApi.streamingLookup");
+    }
+
     // create path and map variables
-    String path = "https://person-stream.clearbit.com/v1/people/email/{email}".replaceAll("\\{" + "email" + "\\}", apiClient.escapeString(email.toString()));
+    String uri = this.STREAMING_URL + "?email=" + apiClient.escapeString(email.toString());
 
-    // query params
-    List<Pair> queryParams = new ArrayList<Pair>();
-    Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, Object> formParams = new HashMap<String, Object>();
-    String accept = apiClient.selectHeaderAccept(new String[]{});
-    String contentType = apiClient.selectHeaderContentType(new String[]{});
-
-    String[] authNames = new String[] { "Basic Authentication" };
-
-    TypeRef<Person> returnType = new TypeRef<Person>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
+    return this.doReq(uri);
   }
 
   /**
@@ -67,34 +56,41 @@ public class PersonApi {
    * @param email the person’s email address
    * @return A cached Person, which may often be null. Registered webhook will receive actual response.
    */
-  public Person lookup(String email, String webhookId) throws ApiException {
-    Object postBody = null;
-    byte[] postBinaryBody = null;
-    
-     // verify the required parameter 'email' is set
-     if (email == null) {
-        throw new ApiException(400, "Missing the required parameter 'email' when calling PersonApi.lookup");
-     }
-     
-    // create path and map variables
-    String path = "https://person.clearbit.com/v1/people/email/{email}"
-        .replaceAll("\\{" + "email" + "\\}", apiClient.escapeString(email.toString()));
-
-    if (webhookId != null) {
-      path += "?webhook_id=" + apiClient.escapeString(webhookId.toString());
-    }
-
-    // query params
-    List<Pair> queryParams = new ArrayList<Pair>();
-    Map<String, String> headerParams = new HashMap<String, String>();
-    Map<String, Object> formParams = new HashMap<String, Object>();
-    String accept = apiClient.selectHeaderAccept(new String[]{});
-    String contentType = apiClient.selectHeaderContentType(new String[]{});
-
-    String[] authNames = new String[] { "Basic Authentication" };
-
-    TypeRef<Person> returnType = new TypeRef<Person>() {};
-    return apiClient.invokeAPI(path, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
+  public Person lookup(String email) throws ApiException {
+    return this.lookup(email, null);
   }
 
+  public Person lookup(String email, String webhookId) throws ApiException {
+    // verify the required parameter 'email' is set
+    if (email == null) {
+      throw new ApiException(400, "Missing the required parameter 'email' when calling PersonApi.lookup");
+    }
+
+    // create path and add url params
+    String uri = this.URL + "?email=" + apiClient.escapeString(email.toString());
+
+    if (webhookId != null) {
+      uri += "&webhook_id=" + apiClient.escapeString(webhookId.toString());
+    }
+
+    return this.doReq(uri);
+  }
+
+  //doReq handles the HTTP request to the API endpoint
+  private Person doReq(String uri) throws ApiException {
+	Object postBody = null;
+	byte[] postBinaryBody = null;
+
+	// query params
+	List<Pair> queryParams = new ArrayList<Pair>();
+	Map<String, String> headerParams = new HashMap<String, String>();
+	Map<String, Object> formParams = new HashMap<String, Object>();
+	String accept = apiClient.selectHeaderAccept(new String[]{});
+	String contentType = apiClient.selectHeaderContentType(new String[]{});
+
+	String[] authNames = new String[] { "Basic Authentication" };
+
+	TypeRef<Person> returnType = new TypeRef<Person>() {};
+	return apiClient.invokeAPI(uri, "GET", queryParams, postBody, postBinaryBody, headerParams, formParams, accept, contentType, authNames, returnType);
+  }
 }

--- a/src/main/lombok/com/clearbit/client/model/Company.java
+++ b/src/main/lombok/com/clearbit/client/model/Company.java
@@ -2,9 +2,9 @@ package com.clearbit.client.model;
 
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 @Data
 public class Company {
@@ -31,6 +31,7 @@ public class Company {
   @JsonProperty Crunchbase crunchbase;
   @JsonProperty Boolean emailProvider;
   @JsonProperty String type;
+  @JsonProperty String ticker;
   @JsonProperty String phone;
   @JsonProperty String indexedAt;
   @JsonProperty List<String> tech;

--- a/src/main/lombok/com/clearbit/client/model/Company.java
+++ b/src/main/lombok/com/clearbit/client/model/Company.java
@@ -14,12 +14,15 @@ public class Company {
   @JsonProperty String legalName;
   @JsonProperty String domain;
   @JsonProperty List<String> domainAliases;
+  @JsonProperty String logo;
   @JsonProperty Site site;
   @JsonProperty List<String> tags;
   @JsonProperty Category category;
   @JsonProperty String description;
   @JsonProperty Integer foundedYear;
   @JsonProperty String location;
+  @JsonProperty String timeZone;
+  @JsonProperty Long utcOffset;
   @JsonProperty Geo geo;
   @JsonProperty Metrics metrics;
   @JsonProperty Facebook facebook;
@@ -27,16 +30,19 @@ public class Company {
   @JsonProperty Twitter twitter;
   @JsonProperty AngelList angellist;
   @JsonProperty Crunchbase crunchbase;
-  @JsonProperty String logo;
   @JsonProperty Boolean emailProvider;
   @JsonProperty String type;
   @JsonProperty String phone;
+  @JsonProperty String indexedAt;
   @JsonProperty List<String> tech;
 
   @Data
   public static class Site {
-    @JsonProperty String url;
     @JsonProperty String title;
+    @JsonProperty String h1;
+    @JsonProperty String metaDescription;
+    @JsonProperty List<String> phoneNumbers;
+    @JsonProperty List<String> emailAddresses;
   }
 
   @Data
@@ -64,14 +70,16 @@ public class Company {
 
   @Data
   public static class Metrics {
-    @JsonProperty Long raised;
-    @JsonProperty Long googleRank;
     @JsonProperty Long alexaUsRank;
     @JsonProperty Long alexaGlobalRank;
     @JsonProperty Long employees;
+    @JsonProperty String employeesRange;
     @JsonProperty Long marketCap;
+    @JsonProperty Long raised;
+    @JsonProperty Long annualRevenue;
+    @JsonProperty Long fiscalYearEnd;
   }
-  
+
   @Data
   public static class Facebook {
     @JsonProperty String handle;

--- a/src/main/lombok/com/clearbit/client/model/Company.java
+++ b/src/main/lombok/com/clearbit/client/model/Company.java
@@ -28,7 +28,6 @@ public class Company {
   @JsonProperty Facebook facebook;
   @JsonProperty LinkedIn linkedin;
   @JsonProperty Twitter twitter;
-  @JsonProperty AngelList angellist;
   @JsonProperty Crunchbase crunchbase;
   @JsonProperty Boolean emailProvider;
   @JsonProperty String type;

--- a/src/main/lombok/com/clearbit/client/model/Person.java
+++ b/src/main/lombok/com/clearbit/client/model/Person.java
@@ -14,6 +14,8 @@ public class Person {
   @JsonProperty String email;
   @JsonProperty String gender;
   @JsonProperty String location;
+  @JsonProperty String timeZone;
+  @JsonProperty Long utcOffset;
   @JsonProperty Geo geo;
   @JsonProperty String bio;
   @JsonProperty String site;
@@ -23,13 +25,11 @@ public class Person {
   @JsonProperty Github github;
   @JsonProperty Twitter twitter;
   @JsonProperty LinkedIn linkedin;
-  @JsonProperty GooglePlus googleplus;
-  @JsonProperty AngelList angellist;
-  @JsonProperty Klout klout;
-  @JsonProperty Foursquare foursquare;
   @JsonProperty AboutMe aboutme;
   @JsonProperty Gravatar gravatar;
   @JsonProperty boolean fuzzy;
+  @JsonProperty boolean emailProvider;
+  @JsonProperty String indexedAt;
 
   @Data
   public static class Name {
@@ -90,33 +90,6 @@ public class Person {
 
   @Data
   public static class LinkedIn {
-    @JsonProperty String handle;
-  }
-
-  @Data
-  public static class GooglePlus {
-    @JsonProperty String handle;
-  }
-
-  @Data
-  public static class AngelList {
-    @JsonProperty String handle;
-    @JsonProperty Long id;
-    @JsonProperty String bio;
-    @JsonProperty String blog;
-    @JsonProperty String site;
-    @JsonProperty Long followers;
-    @JsonProperty String avatar;
-  }
-
-  @Data
-  public static class Klout {
-    @JsonProperty String handle;
-    @JsonProperty String score;
-  }
-
-  @Data
-  public static class Foursquare {
     @JsonProperty String handle;
   }
 

--- a/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
+++ b/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
@@ -12,4 +12,19 @@ public class WebhookResponse {
   int status;
   String id;
 
+  public void setId(String id) {
+	  this.id = id;
+  }
+  
+  public void setStatus(int status) {
+	  this.status = status;
+  }
+  
+  public void setType(Type type) {
+	  this.type = type;	
+  }
+  
+  public void setBody(Object obj) {
+	  this.body = obj;
+  }
 }

--- a/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
+++ b/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
@@ -15,14 +15,14 @@ public class WebhookResponse {
   }
 
   public void setStatus(int status) {
-	this.status = status;
+    this.status = status;
   }
 
   public void setType(Type type) {
-	this.type = type;
+    this.type = type;
   }
 
   public void setBody(Object obj) {
-	this.body = obj;
+    this.body = obj;
   }
 }

--- a/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
+++ b/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
@@ -1,29 +1,27 @@
 package com.clearbit.client.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import lombok.Data;
 
 @Data
 public class WebhookResponse {
-	
+
   Type type;
   Object body;
   int status;
   String id;
 
   public void setId(String id) {
-	  this.id = id;
+    this.id = id;
   }
-  
+
   public void setStatus(int status) {
 	this.status = status;
   }
-  
+
   public void setType(Type type) {
-	this.type = type;	
+	this.type = type;
   }
-  
+
   public void setBody(Object obj) {
 	this.body = obj;
   }

--- a/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
+++ b/src/main/lombok/com/clearbit/client/model/WebhookResponse.java
@@ -6,7 +6,7 @@ import lombok.Data;
 
 @Data
 public class WebhookResponse {
-
+	
   Type type;
   Object body;
   int status;
@@ -17,14 +17,14 @@ public class WebhookResponse {
   }
   
   public void setStatus(int status) {
-	  this.status = status;
+	this.status = status;
   }
   
   public void setType(Type type) {
-	  this.type = type;	
+	this.type = type;	
   }
   
   public void setBody(Object obj) {
-	  this.body = obj;
+	this.body = obj;
   }
 }


### PR DESCRIPTION
Migrate both the person and company apis to v2 URLs.

Major changes:

* Remove deprecated fields from response object

Minor changes:

* Add overloaded functions to Person/Company so `lookup` can be called without webhook ID
* Add setters for webhook

Fixes: https://github.com/clearbit/clearbit-java/issues/12