### PR TITLE
Add parent.domain and estimatedAnnualRevenue to Company model

### DIFF
--- a/src/main/lombok/com/clearbit/client/model/Company.java
+++ b/src/main/lombok/com/clearbit/client/model/Company.java
@@ -35,6 +35,7 @@ public class Company {
   @JsonProperty String phone;
   @JsonProperty String indexedAt;
   @JsonProperty List<String> tech;
+  @JsonProperty Parent parent;
 
   @Data
   public static class Site {
@@ -78,6 +79,7 @@ public class Company {
     @JsonProperty Long raised;
     @JsonProperty Long annualRevenue;
     @JsonProperty Long fiscalYearEnd;
+    @JsonProperty String estimatedAnnualRevenue;
   }
 
   @Data
@@ -115,5 +117,10 @@ public class Company {
   @Data
   public static class Crunchbase {
     @JsonProperty String handle;
+  }
+
+  @Data
+  public static class Parent {
+    @JsonProperty String domain;
   }
 }


### PR DESCRIPTION
The names of the fields are based on this [API docs](https://dashboard.clearbit.com/docs#enrichment-api-company-api)

Fixes: #23 